### PR TITLE
Ignore 'account' directive in netrc files

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -248,21 +248,15 @@ def basicauth_from_netrc(netrc_obj: netrc.netrc, host: str) -> Optional[BasicAut
     if auth_from_netrc is None:
         return None
 
-    login, account, password = auth_from_netrc
-
-    # TODO(PY311): username = login or account
-    # Up to python 3.10, account could be None if not specified,
-    # and login will be empty string if not specified. From 3.11,
-    # login and account will be empty string if not specified.
-    # If login is present, we prefer that over account as username
-    username = login if (login or account is None) else account
+    # second parameter is 'account', which we ignore - it seems primarily useful for FTP
+    login, _, password = auth_from_netrc
 
     # TODO(PY311): Remove this, as password will be empty string
     # if not specified
     if password is None:
         password = ""
 
-    return BasicAuth(username, password)
+    return BasicAuth(login, password)
 
 
 def proxies_from_env() -> Dict[str, ProxyInfo]:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -197,6 +197,7 @@ The client session supports the context manager protocol for self closing.
       .. versionchanged:: 3.9
 
          Added support for reading HTTP Basic Auth credentials from ``~/.netrc`` file.
+         ``account`` directive in ``~/.netrc`` file is now ignored.
 
    :param bool requote_redirect_url: Apply *URL requoting* for redirection URLs if
                                      automatic redirection is enabled (``True`` by

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1006,7 +1006,7 @@ def test_netrc_from_env(netrc_contents: str, hostname: str, expected_username: s
         (
             "machine example.com account username password pass\n",
             "example.com",
-            helpers.BasicAuth("username", "pass"),
+            helpers.BasicAuth("", "pass"),
         ),
         (
             "machine example.com password pass\n",


### PR DESCRIPTION
See https://github.com/aio-libs/aiohttp/pull/7131/files#r1054806166 for more information.

## What do these changes do?

The initial code, which used `account` as *username* if `login` is empty, came from requests (https://github.com/psf/requests/blob/ac3be98b19f4d09c6a970b271a3ae30f3d0858f7/requests/utils.py#L238).

However, I actually believe requests is *wrong* here. If you look at the [inetutils netrc docs](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html), it says:

>  Supply an additional account password. If this token is present, the auto-login process will supply the specified string if the remote server requires an additional account password, or the auto-login process will initiate an ACCT command if it does not.

So it seems to be used as an additional **password**, not as username. I looked up what `ACCT` is, and it seems to be the FTP ACCT command (https://cr.yp.to/ftp/user.html), allowing users to have multiple 'subaccounts' of sorts inside a single login. However, note that even with FTP, you can not use 'ACCT' independent of 'LOGIN'.

I looked at some other clients - curl doesn't even recognize `account` (https://everything.curl.dev/usingcurl/netrc for docs, https://github.com/curl/curl/blob/07dfbc08bfb4322b257d6fae775451ec58e63c80/lib/netrc.c#L65 for code). Neither does httpx (https://github.com/encode/httpx/blob/e5bc1ea533aa5cfcc4f7b179e9faa27f689ed91f/httpx/_utils.py#L152). 

So my suggestion here is to actually *not* follow requests, but instead to follow curl and just ignore the `account` field entirely, as sort of being irrelevant to the HTTP protocol. This would also affect existing users (although I doubt it) though, so if you consider it a breaking change, am happy to submit it as a separate PR that can go into 4.x. I am also happy to keep the status quo - although the digging here was mostly because I realized I could ask myself 'wait, *why* are we prefering login?'.


## Are there changes in behavior for the user?

If users have `account` directives *but* no `login` directive in their `netrc`, it would now be ignored.
However, I think this is somewhat unlikely.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
